### PR TITLE
Add notification workflow and agent setup script

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,0 +1,29 @@
+name: Notify
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '*/15 * * * *'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --release
+      - name: Run bridge
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: ./target/release/another-it-tg-bridge
+      - name: Commit state
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if ! git diff --quiet -- state.json; then
+            git add state.json
+            git commit -m "chore: update state"
+            git push
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent Instructions
+
+1. Run `./scripts/init.sh` to install the required tooling (`rustfmt`, `clippy`, and `cargo-machete`) via prebuilt binaries before starting work.
+2. After making changes, run:
+   - `cargo fmt --all`
+   - `cargo clippy --all-targets --all-features -- -D warnings`
+   - `cargo test`
+   - `cargo machete`
+3. Interpret user requests as actionable tasks and prefer complete pull request solutions over small snippets.
+4. Remove or feature-gate unused code.
+5. Account for potential voice-input typos.
+6. All code comments and Markdown documentation must be in English; responses may be in Russian or English.
+7. Choose the avatar persona that best fits the task and stay in character throughout the interaction. Avatar definitions are available at https://qqrm.github.io/avatars-mcp.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# another-it-tg-bridge
+
+A simple bridge that posts Another IT updates to Telegram.
+
+## GitHub Actions
+
+The workflow at `.github/workflows/notify.yml` builds and runs the binary on a schedule and commits any changes to `state.json`.
+
+Configure the following repository secrets so the workflow can send messages:
+
+- `TELEGRAM_BOT_TOKEN` – Telegram bot token.
+- `TELEGRAM_CHAT_ID` – target chat identifier.
+
+## Development
+
+Run `./scripts/init.sh` to install the required development tools (`rustfmt`, `clippy`, and `cargo-machete`).

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p "$HOME/.cargo/bin"
+
+if ! command -v cargo-binstall >/dev/null 2>&1; then
+  tmpdir="$(mktemp -d)"
+  curl -L "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-gnu.tgz" \
+    | tar -xz -C "$tmpdir"
+  install -m 755 "$tmpdir/cargo-binstall" "$HOME/.cargo/bin/"
+  rm -rf "$tmpdir"
+fi
+
+rustup component add rustfmt clippy
+cargo binstall cargo-machete --no-confirm

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<()> {
     let title = encode_safe(title_raw);
 
     let bot = TelegramBot::from_env()?;
-    let message = format!("{}\n{}", title, url);
+    let message = format!("{title}\n{url}");
     bot.send_message(&message).await?;
 
     state.last_url = Some(url);


### PR DESCRIPTION
## Summary
- Add scheduled GitHub Actions workflow for periodic Telegram notifications
- Document required `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` secrets
- Add tooling init script and update agent instructions with MCP avatar link

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_68a15e0376948332bf266f9494a04f3a