### PR TITLE
Fix pipeline build by adding missing semicolon

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ async fn main() -> Result<()> {
     // Send oldest messages first
     to_send.reverse();
 
-    let bot = TelegramBot::from_env()?
+    let bot = TelegramBot::from_env()?;
     let title_re = Regex::new(r#"<h1[^>]*>(.*?)</h1>"#)?;
     for url in to_send.iter() {
         let article_html = client


### PR DESCRIPTION
## Summary
- fix pipeline by adding missing semicolon in main.rs

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68a1c04c87f08332a82f25538d78dd0c