### PR TITLE
ci: use release binary

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -11,13 +11,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo build --release
+      - name: Download binary
+        run: |
+          curl -L "https://github.com/${{ github.repository }}/releases/download/latest/another-it-tg-bridge" -o another-it-tg-bridge
+          chmod +x another-it-tg-bridge
       - name: Run bridge
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-        run: ./target/release/another-it-tg-bridge
+        run: ./another-it-tg-bridge
       - name: Commit state
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -15,21 +15,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Download sent articles state
         uses: dawidd6/action-download-artifact@v2
         with:
@@ -43,8 +28,10 @@ jobs:
       - name: Ensure data directory exists
         run: mkdir -p data
 
-      - name: Build
-        run: cargo build --release
+      - name: Download binary
+        run: |
+          curl -L "https://github.com/${{ github.repository }}/releases/download/latest/another-it-tg-bridge" -o another-it-tg-bridge
+          chmod +x another-it-tg-bridge
 
       - name: Run
         env:
@@ -52,7 +39,7 @@ jobs:
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           SENT_ARTICLES_PATH: data/sent_articles.json
           RUST_LOG: info
-        run: ./target/release/another-it-tg-bridge
+        run: ./another-it-tg-bridge
 
       - name: Upload sent articles state
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release Binary
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --release
+      - name: Upload binary to release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: latest
+          allowUpdates: true
+          replacesArtifacts: true
+          artifacts: target/release/another-it-tg-bridge
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- build and publish release binary on main
- reuse release binary in scheduled workflows

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68a1ee54e3988332b167057b440480d1