### PR TITLE
feat: allow manual date selection

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -1,0 +1,32 @@
+name: Debug run
+
+on:
+  workflow_dispatch:
+    inputs:
+      date:
+        description: 'Date in DD.MM.YYYY'
+        required: false
+
+jobs:
+  run-bot:
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare target date
+        run: |
+          if [ -n "${{ inputs.date }}" ]; then
+            echo "TARGET_DATE=$(date -d '${{ inputs.date }}' +%Y/%m/%d)" >> $GITHUB_ENV
+          else
+            echo "TARGET_DATE=$(date +%Y/%m/%d)" >> $GITHUB_ENV
+          fi
+      - name: Download binary
+        run: |
+          curl -L "https://github.com/${{ github.repository }}/releases/download/latest/another-it-tg-bridge" -o another-it-tg-bridge
+          chmod +x another-it-tg-bridge
+      - name: Run
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          RUST_LOG: warn
+        run: ./another-it-tg-bridge

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,13 @@
 # Agent Instructions
 
-1. Run `./scripts/init.sh` to install the required tooling (`rustfmt`, `clippy`, and `cargo-machete`) via prebuilt binaries before starting work.
-2. After making changes, run:
+1. Always roleplay as the "DevOps Engineer" avatar from the MCP server and stay in character throughout the interaction.
+2. Run `./scripts/init.sh` to install the required tooling (`rustfmt`, `clippy`, and `cargo-machete`) via prebuilt binaries before starting work.
+3. After making changes, run:
    - `cargo fmt --all`
    - `cargo clippy --all-targets --all-features -- -D warnings`
    - `cargo test`
    - `cargo machete`
-3. Interpret user requests as actionable tasks and prefer complete pull request solutions over small snippets.
-4. Remove or feature-gate unused code.
-5. Account for potential voice-input typos.
-6. All code comments and Markdown documentation must be in English; responses may be in Russian or English.
-7. Choose the avatar persona that best fits the task and stay in character throughout the interaction. Avatar definitions are available at https://qqrm.github.io/avatars-mcp.
+4. Interpret user requests as actionable tasks and prefer complete pull request solutions over small snippets.
+5. Remove or feature-gate unused code.
+6. Account for potential voice-input typos.
+7. All code comments and Markdown documentation must be in English; responses may be in Russian or English.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Posts new articles from [another-it.ru](https://another-it.ru/) to a Telegram ch
 - `TELEGRAM_CHAT_ID` – target chat identifier.
 - `SENT_ARTICLES_PATH` – path to the JSON file that stores already sent URLs (`state.json` by default).
 - `RUST_LOG` – optional logging level (e.g., `info`).
+- `TARGET_DATE` – optional date in `YYYY/MM/DD` used to filter posts.
 
 ## Manual run
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,11 +13,13 @@ const HOME_URL: &str = "https://another-it.ru/";
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
+    let target_date = std::env::var("TARGET_DATE").ok();
+
     let run_number: u64 = std::env::var("GITHUB_RUN_NUMBER")
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(0);
-    let is_first_run = run_number <= 1;
+    let is_first_run = run_number <= 1 && target_date.is_none();
     let client = reqwest::Client::new();
 
     let html = client
@@ -36,8 +38,8 @@ async fn main() -> Result<()> {
     urls.truncate(10);
 
     if !is_first_run {
-        let today = Utc::now().format("%Y/%m/%d").to_string();
-        urls.retain(|u| u.contains(&today));
+        let filter_date = target_date.unwrap_or_else(|| Utc::now().format("%Y/%m/%d").to_string());
+        urls.retain(|u| u.contains(&filter_date));
     }
 
     if urls.is_empty() {


### PR DESCRIPTION
## Summary
- move date formatting into workflow and read pre-formatted `TARGET_DATE` in the binary
- add workflow step that sets `TARGET_DATE` to manual or current date
- document expected format for `TARGET_DATE`
- document default avatar instruction for contributors

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68a314ecd9648332884f0277511bcc82