### PR TITLE
ci: run workflows using release binary

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -22,7 +22,9 @@ jobs:
           fi
       - name: Download binary
         run: |
-          curl -L "https://github.com/${{ github.repository }}/releases/download/latest/another-it-tg-bridge" -o another-it-tg-bridge
+          curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -o another-it-tg-bridge \
+            https://github.com/${{ github.repository }}/releases/download/latest/another-it-tg-bridge
           chmod +x another-it-tg-bridge
       - name: Run
         env:

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -14,7 +14,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Download binary
         run: |
-          curl -L "https://github.com/${{ github.repository }}/releases/download/latest/another-it-tg-bridge" -o another-it-tg-bridge
+          curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -o another-it-tg-bridge \
+            https://github.com/${{ github.repository }}/releases/download/latest/another-it-tg-bridge
           chmod +x another-it-tg-bridge
       - name: Run bridge
         env:

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -15,10 +15,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Download binary
         run: |
-          curl -L "https://github.com/${{ github.repository }}/releases/download/latest/another-it-tg-bridge" -o another-it-tg-bridge
+          curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -o another-it-tg-bridge \
+            https://github.com/${{ github.repository }}/releases/download/latest/another-it-tg-bridge
           chmod +x another-it-tg-bridge
 
       - name: Run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: latest
+          commit: ${{ github.sha }}
           allowUpdates: true
           replacesArtifacts: true
           artifacts: target/release/another-it-tg-bridge


### PR DESCRIPTION
## Summary
- download release binary in debug, notify, and post workflows
- avoid recompilation by using GITHUB_TOKEN for authenticated binary fetch

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68a3adbc31f08332815c3f70c360602d