### PR TITLE
Allow overriding target date with CLI argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Posts new articles from [another-it.ru](https://another-it.ru/) to a Telegram ch
 - `TELEGRAM_CHAT_ID` – target chat identifier.
 - `SENT_ARTICLES_PATH` – path to the JSON file that stores already sent URLs (`state.json` by default).
 - `RUST_LOG` – optional logging level (e.g., `info`).
-- `TARGET_DATE` – optional date in `YYYY/MM/DD` used to filter posts.
+- `TARGET_DATE` – optional date in `YYYY/MM/DD` used to filter posts. The same value can be
+  provided as the first command line argument for debugging.
 
 ## Manual run
 
@@ -32,6 +33,8 @@ export TELEGRAM_CHAT_ID=...
 # optional
 export SENT_ARTICLES_PATH=state.json
 cargo run --release
+# For debugging a specific date:
+# cargo run --release 2025/05/26
 ```
 
 ## GitHub Actions

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,10 @@ const HOME_URL: &str = "https://another-it.ru/";
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
-    let target_date = std::env::var("TARGET_DATE").ok();
+    // First command line argument overrides TARGET_DATE for debugging
+    let target_date = std::env::args()
+        .nth(1)
+        .or_else(|| std::env::var("TARGET_DATE").ok());
 
     let run_number: u64 = std::env::var("GITHUB_RUN_NUMBER")
         .ok()


### PR DESCRIPTION
## Summary
- let CLI argument override `TARGET_DATE` for easier debugging
- document date argument usage in README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68a3e74797c483329f379c4848f173c8