### PR TITLE
ci: show info logs in pipelines

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -30,5 +30,5 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          RUST_LOG: warn
+          RUST_LOG: info
         run: ./another-it-tg-bridge

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ vars.TELEGRAM_CHAT_ID }}
-          RUST_LOG: warn
+          RUST_LOG: info
         run: ./another-it-tg-bridge
       - name: Commit state
         run: |

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          RUST_LOG: warn
+          RUST_LOG: info
         run: ./another-it-tg-bridge
 
       - name: Notify failure


### PR DESCRIPTION
## Summary
- emit info level RUST logs in all workflows

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68a3fa26d9a4833295cd2f79aa9f4c00