### PR TITLE
Fix debug workflow binary download path

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -o another-it-tg-bridge \
-            https://github.com/${{ github.repository }}/releases/download/latest/another-it-tg-bridge
+            https://github.com/${{ github.repository }}/releases/latest/download/another-it-tg-bridge
           chmod +x another-it-tg-bridge
       - name: Run
         env:


### PR DESCRIPTION
## Summary
- use `/releases/latest/download` for debug workflow binary

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68a40035741c8332a6783d36e97665fc