### PR TITLE
chore: run notify daily for previous day

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -3,7 +3,7 @@ name: Notify
 on:
   workflow_dispatch:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '0 9 * * *' # 12:00 Moscow time (UTC+3)
 
 jobs:
   notify:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod telegram;
 
 use anyhow::{Context, Result};
-use chrono::{FixedOffset, Utc};
+use chrono::{Duration as ChronoDuration, FixedOffset, Utc};
 use html_escape::encode_safe;
 use log::{info, warn};
 use regex::Regex;
@@ -42,10 +42,10 @@ async fn main() -> Result<()> {
 
     if !is_first_run {
         let filter_date = target_date.unwrap_or_else(|| {
-            Utc::now()
-                .with_timezone(&FixedOffset::east_opt(3 * 3600).unwrap())
-                .format("%Y/%m/%d")
-                .to_string()
+            (Utc::now().with_timezone(&FixedOffset::east_opt(3 * 3600).unwrap())
+                - ChronoDuration::days(1))
+            .format("%Y/%m/%d")
+            .to_string()
         });
         urls.retain(|u| u.contains(&filter_date));
     }


### PR DESCRIPTION
## Summary
- schedule notify workflow daily at Moscow noon
- filter posts by previous day

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68a4263ac21083328b905da704a0a1fe