### PR TITLE
chore: install wrkflw

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The workflow at `.github/workflows/post.yml` builds the binary on a schedule or 
 
 ## Development
 
-Run `./scripts/init.sh` to install the required development tools (`rustfmt`, `clippy`, and `cargo-machete`).
+Run `./scripts/init.sh` to install the required development tools (`rustfmt`, `clippy`, `cargo-machete`, and `wrkflw`).
 
 ## Origins
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -13,3 +13,13 @@ fi
 
 rustup component add rustfmt clippy
 cargo binstall cargo-machete --no-confirm
+
+if ! command -v wrkflw >/dev/null 2>&1; then
+  cargo binstall wrkflw@0.7.0 --no-confirm || {
+    tmpdir="$(mktemp -d)"
+    curl -L "https://github.com/bahdotsh/wrkflw/releases/download/v0.7.0/wrkflw-v0.7.0-linux-x86_64.tar.gz" \
+      | tar -xz -C "$tmpdir"
+    install -m 755 "$tmpdir/wrkflw" "$HOME/.cargo/bin/"
+    rm -rf "$tmpdir"
+  }
+fi


### PR DESCRIPTION
## Summary
- install wrkflw v0.7.0 via cargo-binstall with release fallback
- document wrkflw in development tooling

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68a42b95d47883328525e60331b9d764