### PR TITLE
Filter posts by date before truncation

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       date:
-        description: 'Date in DD.MM.YYYY'
+        description: 'Date in YYYY/MM/DD'
         required: false
 
 jobs:
@@ -15,7 +15,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare target date
         run: |
-          if [ -n "$INPUT_DATE" ]; then echo "TARGET_DATE=$(date -d "$INPUT_DATE" +%Y/%m/%d)" >> "$GITHUB_ENV"; else echo "TARGET_DATE=$(date +%Y/%m/%d)" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUT_DATE" ]; then
+            echo "TARGET_DATE=$(date -d \"$INPUT_DATE\" +%Y/%m/%d)" >> "$GITHUB_ENV"
+          else
+            echo "TARGET_DATE=$(date +%Y/%m/%d)" >> "$GITHUB_ENV"
+          fi
       - name: Download binary
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/specifications.md
+++ b/specifications.md
@@ -1,0 +1,5 @@
+# Specifications
+
+## Debug workflow
+- The `date` input and `TARGET_DATE` environment variable use the `YYYY/MM/DD` format.
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,8 +40,6 @@ async fn main() -> Result<()> {
         .map(|c| c.get(1).unwrap().as_str().to_string())
         .collect();
     debug!("fetched {} urls", urls.len());
-    urls.truncate(10);
-    debug!("urls after truncate: {urls:?}");
 
     if !is_first_run {
         let filter_date = target_date.unwrap_or_else(|| {
@@ -53,6 +51,9 @@ async fn main() -> Result<()> {
         debug!("filtering by date {filter_date}");
         urls.retain(|u| u.contains(&filter_date));
         debug!("urls after filtering: {urls:?}");
+    } else {
+        urls.truncate(10);
+        debug!("urls after truncate: {urls:?}");
     }
 
     if urls.is_empty() {


### PR DESCRIPTION
## Summary
- collect all homepage links and filter by date before truncating first-run posts

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`
- `RUST_LOG=debug cargo run --release -- 2025/06/14`


------
https://chatgpt.com/codex/tasks/task_e_68a440807df4833291c34e9fd2e582af