### PR TITLE
fix: allow notify workflow to push state

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -9,6 +9,8 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     environment: prod
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -18,7 +20,7 @@ jobs:
         run: |
           curl -L -H "Authorization: Bearer $GITHUB_TOKEN" \
             -o another-it-tg-bridge \
-            "https://github.com/$GITHUB_REPOSITORY/releases/download/latest/another-it-tg-bridge"
+            "https://github.com/$GITHUB_REPOSITORY/releases/latest/download/another-it-tg-bridge"
           chmod +x another-it-tg-bridge
       - name: Run bridge
         env:

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           curl -L -H "Authorization: Bearer $GITHUB_TOKEN" \
             -o another-it-tg-bridge \
-            "https://github.com/$GITHUB_REPOSITORY/releases/download/latest/another-it-tg-bridge"
+            "https://github.com/$GITHUB_REPOSITORY/releases/latest/download/another-it-tg-bridge"
           chmod +x another-it-tg-bridge
 
       - name: Run


### PR DESCRIPTION
## Summary
- add write permission to notify workflow
- download binary from latest release in notify and post workflows

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68a53358d0608332a959290a51de1e0d