### PR TITLE
Improve Google link discovery and debug backfill

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  analyze:
+    name: Analyze (rust)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: rust
+            build-mode: autobuild
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         include:
           - language: rust
-            build-mode: autobuild
+            build-mode: none
 
     steps:
       - uses: actions/checkout@v4
@@ -30,9 +30,6 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
 
       - name: Analyze
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -4,8 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       date:
-        description: 'Date in YYYY/MM/DD or YYYY-MM-DD'
-        required: true
+        description: 'Optional single date in YYYY/MM/DD or YYYY-MM-DD'
+        required: false
+      days:
+        description: 'Trailing days including today when date is empty'
+        required: false
+        default: '14'
 
 jobs:
   run-bot:
@@ -17,24 +21,36 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download binary from latest release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release download latest -p another-it-tg-bridge -O another-it-tg-bridge
-          chmod +x another-it-tg-bridge
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build binary
+        run: cargo build --release
 
       - name: Check config
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ vars.TELEGRAM_CHAT_ID }}
+          TELEGRAM_CHAT_ID: ${{ vars.DEV_TELEGRAM_CHAT_ID || vars.TELEGRAM_CHAT_ID }}
+          GOOGLE_CSE_API_KEY: ${{ secrets.GOOGLE_CSE_API_KEY }}
+          GOOGLE_CSE_CX: ${{ secrets.GOOGLE_CSE_CX }}
         run: |
           : "${TELEGRAM_BOT_TOKEN:?missing TELEGRAM_BOT_TOKEN}"
           : "${TELEGRAM_CHAT_ID:?missing TELEGRAM_CHAT_ID}"
+          : "${GOOGLE_CSE_API_KEY:?missing GOOGLE_CSE_API_KEY}"
+          : "${GOOGLE_CSE_CX:?missing GOOGLE_CSE_CX}"
 
       - name: Run
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ vars.TELEGRAM_CHAT_ID }}
+          TELEGRAM_CHAT_ID: ${{ vars.DEV_TELEGRAM_CHAT_ID || vars.TELEGRAM_CHAT_ID }}
+          GOOGLE_CSE_API_KEY: ${{ secrets.GOOGLE_CSE_API_KEY }}
+          GOOGLE_CSE_CX: ${{ secrets.GOOGLE_CSE_CX }}
+          STATE_PATH: state/debug_sent_urls.txt
+          DEBUG_DATE: ${{ github.event.inputs.date }}
+          DEBUG_DAYS: ${{ github.event.inputs.days }}
           RUST_LOG: info
-        run: ./another-it-tg-bridge "${{ github.event.inputs.date }}"
+        run: |
+          if [ -n "${DEBUG_DATE}" ]; then
+            ./target/release/another-it-tg-bridge "${DEBUG_DATE}"
+          else
+            ./target/release/another-it-tg-bridge --days "${DEBUG_DAYS}"
+          fi

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -10,6 +10,10 @@ on:
         description: 'Trailing days including today when date is empty'
         required: false
         default: '14'
+      resolve_chat_id:
+        description: 'Print recent Telegram chat ids instead of sending posts'
+        required: false
+        default: 'false'
 
 jobs:
   run-bot:
@@ -32,13 +36,48 @@ jobs:
           TELEGRAM_CHAT_ID: ${{ vars.DEV_TELEGRAM_CHAT_ID || vars.TELEGRAM_CHAT_ID }}
           GOOGLE_CSE_API_KEY: ${{ secrets.GOOGLE_CSE_API_KEY }}
           GOOGLE_CSE_CX: ${{ secrets.GOOGLE_CSE_CX }}
+          RESOLVE_CHAT_ID: ${{ github.event.inputs.resolve_chat_id }}
         run: |
           : "${TELEGRAM_BOT_TOKEN:?missing TELEGRAM_BOT_TOKEN}"
-          : "${TELEGRAM_CHAT_ID:?missing TELEGRAM_CHAT_ID}"
-          : "${GOOGLE_CSE_API_KEY:?missing GOOGLE_CSE_API_KEY}"
-          : "${GOOGLE_CSE_CX:?missing GOOGLE_CSE_CX}"
+          if [ "${RESOLVE_CHAT_ID}" != "true" ]; then
+            : "${TELEGRAM_CHAT_ID:?missing TELEGRAM_CHAT_ID}"
+            : "${GOOGLE_CSE_API_KEY:?missing GOOGLE_CSE_API_KEY}"
+            : "${GOOGLE_CSE_CX:?missing GOOGLE_CSE_CX}"
+          fi
+
+      - name: Resolve chat ids
+        if: ${{ github.event.inputs.resolve_chat_id == 'true' }}
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+        run: |
+          response="$(curl -fsS "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getUpdates")"
+          echo "$response" \
+            | jq -r '
+                [
+                  .result[]
+                  | [
+                      .message.chat?,
+                      .edited_message.chat?,
+                      .channel_post.chat?,
+                      .edited_channel_post.chat?,
+                      .my_chat_member.chat?,
+                      .chat_member.chat?
+                    ]
+                  | .[]
+                  | select(. != null)
+                ]
+                | unique_by(.id)
+                | sort_by(.id)
+                | if length == 0 then
+                    "No recent chats found. Send a fresh message or channel post, then rerun this workflow."
+                  else
+                    .[]
+                    | "chat_id=\(.id) type=\(.type) title=\(.title // "-") username=\(.username // "-")"
+                  end
+              '
 
       - name: Run
+        if: ${{ github.event.inputs.resolve_chat_id != 'true' }}
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ vars.DEV_TELEGRAM_CHAT_ID || vars.TELEGRAM_CHAT_ID }}

--- a/.github/workflows/resolve-debug-chat.yml
+++ b/.github/workflows/resolve-debug-chat.yml
@@ -1,0 +1,48 @@
+name: Resolve Debug Chat
+
+on:
+  workflow_dispatch:
+
+jobs:
+  resolve-chat:
+    runs-on: ubuntu-latest
+    environment: prod
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check config
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+        run: |
+          : "${TELEGRAM_BOT_TOKEN:?missing TELEGRAM_BOT_TOKEN}"
+
+      - name: Fetch recent chat ids
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+        run: |
+          response="$(curl -fsS "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getUpdates")"
+          echo "$response" \
+            | jq -r '
+                [
+                  .result[]
+                  | [
+                      .message.chat?,
+                      .edited_message.chat?,
+                      .channel_post.chat?,
+                      .edited_channel_post.chat?,
+                      .my_chat_member.chat?,
+                      .chat_member.chat?
+                    ]
+                  | .[]
+                  | select(. != null)
+                ]
+                | unique_by(.id)
+                | sort_by(.id)
+                | if length == 0 then
+                    "No recent chats found. Send a fresh message or channel post, then rerun this workflow."
+                  else
+                    .[]
+                    | "chat_id=\(.id) type=\(.type) title=\(.title // "-") username=\(.username // "-")"
+                  end
+              '

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,6 @@ dependencies = [
  "chrono",
  "env_logger",
  "log",
- "regex",
  "reqwest",
  "serde",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,4 @@ anyhow = "1"
 log = "0.4"
 env_logger = "0.11"
 chrono = "0.4"
-regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Posts new articles from [another-it.ru](https://another-it.ru/) to the [another_
    - `TELEGRAM_CHAT_ID` – target chat identifier.
    - `GOOGLE_CSE_API_KEY` – Google Custom Search API key.
    - `GOOGLE_CSE_CX` – Programmable Search Engine ID.
-   - (optional) `DEV_TELEGRAM_CHAT_ID` – chat for workflow failure notifications.
+   - (optional) `DEV_TELEGRAM_CHAT_ID` – debug chat identifier for manual backfills.
 3. Enable GitHub Actions for the repository if it is disabled.
 4. Trigger the workflow: open the **Actions** tab, select **Post to Telegram**, and click **Run workflow** (`workflow_dispatch`).
 
@@ -36,9 +36,22 @@ export GOOGLE_CSE_CX=...
 cargo run --release
 ```
 
+Pass an optional date argument (`YYYY/MM/DD` or `YYYY-MM-DD`) to probe a single day via Google CSE:
+
+```sh
+cargo run --release -- 2026-03-28
+```
+
+Pass `--days N` to scan a trailing window including today:
+
+```sh
+cargo run --release -- --days 14
+```
+
 ## GitHub Actions
 
-The workflow at `.github/workflows/post.yml` builds the binary on a schedule or manual dispatch and caches the sent URL state.
+The workflow at `.github/workflows/post.yml` builds the binary on a schedule or manual dispatch and caches the sent URL state. Scheduled runs query Google CSE for the recent date prefixes to absorb indexing delays while still deduplicating already-sent links.
+The manual workflow at `.github/workflows/debug.yml` targets `DEV_TELEGRAM_CHAT_ID` when present and defaults to a 14-day backfill into an isolated debug state file.
 Rust toolchain updates are handled by Dependabot with auto-merge enabled for its pull requests.
 
 ## Development

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,8 @@
 mod telegram;
 
 use anyhow::{Context, Result};
-use chrono::{Duration as ChronoDuration, FixedOffset, NaiveDate, Utc};
+use chrono::{Datelike, Duration as ChronoDuration, FixedOffset, NaiveDate, Utc};
 use log::{info, warn};
-use regex::Regex;
 use reqwest::Client;
 use serde::Deserialize;
 use std::collections::HashSet;
@@ -12,9 +11,10 @@ use std::path::Path;
 use telegram::TelegramBot;
 
 const GOOGLE_CSE_ENDPOINT: &str = "https://www.googleapis.com/customsearch/v1";
-const GOOGLE_QUERY: &str = "site:another-it.ru";
-const STATE_PATH: &str = "state/sent_urls.txt";
-const DATE_WINDOW_DAYS: i64 = 30;
+const GOOGLE_QUERY_PREFIX: &str = "site:another-it.ru/";
+const DEFAULT_STATE_PATH: &str = "state/sent_urls.txt";
+const STATE_RETENTION_DAYS: i64 = 30;
+const AUTO_LOOKBACK_DAYS: i64 = 7;
 const GOOGLE_RESULTS: u8 = 10;
 
 #[tokio::main]
@@ -24,22 +24,40 @@ async fn main() -> Result<()> {
     let client = Client::new();
     let api_key = std::env::var("GOOGLE_CSE_API_KEY").context("GOOGLE_CSE_API_KEY missing")?;
     let cx = std::env::var("GOOGLE_CSE_CX").context("GOOGLE_CSE_CX missing")?;
+    let state_path = std::env::var("STATE_PATH").unwrap_or_else(|_| DEFAULT_STATE_PATH.to_string());
 
     let tz = FixedOffset::east_opt(3 * 3600).unwrap();
     let today_msk = Utc::now().with_timezone(&tz).date_naive();
-    let window_start = today_msk - ChronoDuration::days(DATE_WINDOW_DAYS);
-    let article_re = Regex::new(
-        r"^https://another-it\.ru/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/[^/]+/?$",
-    )
-    .unwrap();
+    let state_window_start = today_msk - ChronoDuration::days(STATE_RETENTION_DAYS);
+    let target_dates = determine_target_dates(today_msk)?;
+    info!("checking {} dates via Google CSE", target_dates.len());
 
-    let items = fetch_items(&client, &api_key, &cx).await?;
-    info!("google cse returned {} items", items.len());
+    let mut articles = Vec::new();
+    for target_date in target_dates {
+        let items = fetch_items(&client, &api_key, &cx, &google_query(target_date)).await?;
+        info!(
+            "google cse returned {} items for {}",
+            items.len(),
+            target_date.format("%Y-%m-%d")
+        );
 
-    let articles = filter_items(items, &article_re, window_start, today_msk);
-    info!("links after filtering: {}", articles.len());
+        let filtered = filter_items(&items, target_date);
+        if filtered.is_empty() && !items.is_empty() {
+            info!(
+                "google candidate links for {}: {}",
+                target_date.format("%Y-%m-%d"),
+                format_candidate_links(&items)
+            );
+        }
+        info!(
+            "links after filtering for {}: {}",
+            target_date.format("%Y-%m-%d"),
+            filtered.len()
+        );
+        articles.extend(filtered);
+    }
 
-    let mut sent_urls = load_state(STATE_PATH)?;
+    let mut sent_urls = load_state(&state_path)?;
     let mut new_articles: Vec<Article> = articles
         .into_iter()
         .filter(|article| !sent_urls.contains(&article.url))
@@ -50,8 +68,8 @@ async fn main() -> Result<()> {
     info!("new links to send: {}", new_articles.len());
 
     if new_articles.is_empty() {
-        retain_recent(&mut sent_urls, &article_re, window_start, today_msk);
-        persist_state(STATE_PATH, &sent_urls)?;
+        retain_recent(&mut sent_urls, state_window_start, today_msk);
+        persist_state(&state_path, &sent_urls)?;
         info!("no new posts");
         return Ok(());
     }
@@ -82,8 +100,8 @@ async fn main() -> Result<()> {
 
     info!("sent {} new links, failed {}", sent, failed);
 
-    retain_recent(&mut sent_urls, &article_re, window_start, today_msk);
-    persist_state(STATE_PATH, &sent_urls)?;
+    retain_recent(&mut sent_urls, state_window_start, today_msk);
+    persist_state(&state_path, &sent_urls)?;
 
     if failed > 0 {
         anyhow::bail!("telegram delivery failed for {} links", failed);
@@ -110,13 +128,17 @@ struct Article {
     date: NaiveDate,
 }
 
-async fn fetch_items(client: &Client, api_key: &str, cx: &str) -> Result<Vec<CseItem>> {
+async fn fetch_items(
+    client: &Client,
+    api_key: &str,
+    cx: &str,
+    query: &str,
+) -> Result<Vec<CseItem>> {
     let params = [
         ("key", api_key.to_string()),
         ("cx", cx.to_string()),
-        ("q", GOOGLE_QUERY.to_string()),
+        ("q", query.to_string()),
         ("num", GOOGLE_RESULTS.to_string()),
-        ("dateRestrict", format!("d{DATE_WINDOW_DAYS}")),
     ];
 
     let resp = client
@@ -139,33 +161,130 @@ async fn fetch_items(client: &Client, api_key: &str, cx: &str) -> Result<Vec<Cse
     Ok(payload.items.unwrap_or_default())
 }
 
-fn filter_items(
-    items: Vec<CseItem>,
-    article_re: &Regex,
-    window_start: NaiveDate,
-    today: NaiveDate,
-) -> Vec<Article> {
+fn filter_items(items: &[CseItem], target_date: NaiveDate) -> Vec<Article> {
     items
-        .into_iter()
+        .iter()
         .filter_map(|item| {
-            let date = extract_date(&item.link, article_re)?;
-            if date < window_start || date > today {
-                return None;
-            }
+            let url = normalize_article_url(&item.link, target_date)?;
             Some(Article {
-                url: item.link,
-                title: item.title,
-                date,
+                url,
+                title: item
+                    .title
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|title| !title.is_empty())
+                    .map(str::to_string),
+                date: target_date,
             })
         })
         .collect()
 }
 
-fn extract_date(url: &str, article_re: &Regex) -> Option<NaiveDate> {
-    let caps = article_re.captures(url)?;
-    let year = caps.name("year")?.as_str().parse().ok()?;
-    let month = caps.name("month")?.as_str().parse().ok()?;
-    let day = caps.name("day")?.as_str().parse().ok()?;
+fn google_query(target_date: NaiveDate) -> String {
+    format!("{GOOGLE_QUERY_PREFIX}{}/", target_date.format("%Y/%m/%d"))
+}
+
+fn determine_target_dates(today_msk: NaiveDate) -> Result<Vec<NaiveDate>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.as_slice() {
+        [] => Ok((1..=AUTO_LOOKBACK_DAYS)
+            .map(|days_ago| today_msk - ChronoDuration::days(days_ago))
+            .collect()),
+        [date] => Ok(vec![parse_date_arg(date)?]),
+        [flag, days] if flag == "--days" => trailing_dates(today_msk, parse_days_arg(days)?),
+        _ => anyhow::bail!("usage: another-it-tg-bridge [YYYY/MM/DD|YYYY-MM-DD] [--days N]"),
+    }
+}
+
+fn trailing_dates(today_msk: NaiveDate, days: i64) -> Result<Vec<NaiveDate>> {
+    if days <= 0 {
+        anyhow::bail!("days must be greater than 0");
+    }
+
+    Ok((0..days)
+        .map(|days_ago| today_msk - ChronoDuration::days(days_ago))
+        .collect())
+}
+
+fn parse_date_arg(input: &str) -> Result<NaiveDate> {
+    let normalized = input.replace('-', "/");
+    NaiveDate::parse_from_str(&normalized, "%Y/%m/%d").context("invalid date")
+}
+
+fn parse_days_arg(input: &str) -> Result<i64> {
+    input.parse::<i64>().context("invalid days")
+}
+
+fn normalize_article_url(raw_url: &str, target_date: NaiveDate) -> Option<String> {
+    let mut url = reqwest::Url::parse(raw_url).ok()?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return None;
+    }
+
+    match url.host_str()? {
+        "another-it.ru" | "www.another-it.ru" => {}
+        _ => return None,
+    }
+
+    let expected_segments = [
+        target_date.year().to_string(),
+        format!("{:02}", target_date.month()),
+        format!("{:02}", target_date.day()),
+    ];
+
+    let path_segments: Vec<String> = url
+        .path_segments()?
+        .filter(|segment| !segment.is_empty())
+        .map(str::to_string)
+        .collect();
+    if path_segments.len() != 4 || path_segments[3].is_empty() {
+        return None;
+    }
+    if path_segments[0] != expected_segments[0]
+        || path_segments[1] != expected_segments[1]
+        || path_segments[2] != expected_segments[2]
+    {
+        return None;
+    }
+
+    url.set_scheme("https").ok()?;
+    url.set_host(Some("another-it.ru")).ok()?;
+    url.set_query(None);
+    url.set_fragment(None);
+    url.set_path(&format!(
+        "/{}/{}/{}/{}/",
+        path_segments[0], path_segments[1], path_segments[2], path_segments[3]
+    ));
+
+    Some(url.into())
+}
+
+fn format_candidate_links(items: &[CseItem]) -> String {
+    items
+        .iter()
+        .map(|item| item.link.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn extract_date(url: &str) -> Option<NaiveDate> {
+    let parsed = reqwest::Url::parse(url).ok()?;
+    match parsed.host_str()? {
+        "another-it.ru" | "www.another-it.ru" => {}
+        _ => return None,
+    }
+
+    let segments: Vec<_> = parsed
+        .path_segments()?
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    if segments.len() != 4 {
+        return None;
+    }
+
+    let year = segments[0].parse().ok()?;
+    let month = segments[1].parse().ok()?;
+    let day = segments[2].parse().ok()?;
     NaiveDate::from_ymd_opt(year, month, day)
 }
 
@@ -182,15 +301,9 @@ fn load_state(path: &str) -> Result<HashSet<String>> {
     }
 }
 
-fn retain_recent(
-    sent_urls: &mut HashSet<String>,
-    article_re: &Regex,
-    window_start: NaiveDate,
-    today: NaiveDate,
-) {
-    sent_urls.retain(|url| {
-        extract_date(url, article_re).is_some_and(|date| date >= window_start && date <= today)
-    });
+fn retain_recent(sent_urls: &mut HashSet<String>, window_start: NaiveDate, today: NaiveDate) {
+    sent_urls
+        .retain(|url| extract_date(url).is_some_and(|date| date >= window_start && date <= today));
 }
 
 fn persist_state(path: &str, sent_urls: &HashSet<String>) -> Result<()> {
@@ -201,4 +314,53 @@ fn persist_state(path: &str, sent_urls: &HashSet<String>) -> Result<()> {
     urls.sort();
     let payload = urls.join("\n");
     fs::write(path, payload).context("failed to write state file")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_debug_date_with_dashes() {
+        let date = parse_date_arg("2026-03-28").unwrap();
+        assert_eq!(date, NaiveDate::from_ymd_opt(2026, 3, 28).unwrap());
+    }
+
+    #[test]
+    fn parses_days_argument() {
+        assert_eq!(parse_days_arg("14").unwrap(), 14);
+    }
+
+    #[test]
+    fn trailing_dates_include_today() {
+        let today = NaiveDate::from_ymd_opt(2026, 3, 30).unwrap();
+        let dates = trailing_dates(today, 3).unwrap();
+
+        assert_eq!(
+            dates,
+            vec![
+                NaiveDate::from_ymd_opt(2026, 3, 30).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 3, 29).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 3, 28).unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn normalizes_article_url_and_strips_query() {
+        let target_date = NaiveDate::from_ymd_opt(2026, 3, 28).unwrap();
+        let normalized = normalize_article_url(
+            "http://www.another-it.ru/2026/03/28/test-post/?utm_source=google#frag",
+            target_date,
+        )
+        .unwrap();
+
+        assert_eq!(normalized, "https://another-it.ru/2026/03/28/test-post/");
+    }
+
+    #[test]
+    fn rejects_archive_page_urls() {
+        let target_date = NaiveDate::from_ymd_opt(2026, 3, 28).unwrap();
+        assert!(normalize_article_url("https://another-it.ru/2026/03/28/", target_date).is_none());
+    }
 }


### PR DESCRIPTION
## Summary
Improve Google CSE link discovery by querying date-specific prefixes, add debug backfill support, and route manual debug runs to a dedicated debug chat.

## Problem
The scheduled workflow queried Google too broadly (`site:another-it.ru`), so recent article URLs were not being filtered into sendable links. Manual debug runs also could not target a separate debug chat or backfill a recent window.

## Solution
Use date-specific Google CSE queries and URL normalization in the Rust binary, add a `--days` backfill mode, and update the debug workflow to build the current ref, resolve Telegram chat ids, and send to `DEV_TELEGRAM_CHAT_ID` when present.

## Scope
Included: Google query changes, debug/backfill workflow changes, debug chat resolution support, README updates, and dependency cleanup.
Not included: changes to the production scheduled workflow cadence beyond using the new query logic after merge/release.

## Validation
- `wrkflw validate`
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`
- Manual debug workflow run on branch `codex/debug-backfill-chat` confirmed 6 article links reached the debug chat.

## Risks
Direct push to `main` is blocked by repository rules, so merge still depends on GitHub allowing the PR path. Google indexing gaps remain possible for dates where CSE returns zero items.
